### PR TITLE
Fix remainder operator over X=0 and Y=0

### DIFF
--- a/src/main/java/fourteener/worldeditor/operations/operators/RemainderNode.java
+++ b/src/main/java/fourteener/worldeditor/operations/operators/RemainderNode.java
@@ -26,16 +26,16 @@ public class RemainderNode extends Node {
 		int base = (int) arg2.getValue();
 		int modBase = base * 2;
 		if (arg1 == 0) {
-			int posVal = Math.abs(Operator.currentBlock.getX());
-			return (posVal % modBase) < base;
+			int value = Operator.currentBlock.getX();
+			return Math.floorMod(value, modBase) < base;
 		}
 		else if (arg1 == 1) {
-			int posVal = Math.abs(Operator.currentBlock.getY());
-			return (posVal % modBase) < base;
+			int value = Operator.currentBlock.getY();
+			return Math.floorMod(value, modBase) < base;
 		}
 		else if (arg1 == 2) {
-			int posVal = Math.abs(Operator.currentBlock.getZ());
-			return (posVal % modBase) < base;
+			int value =  Operator.currentBlock.getZ();
+			return Math.floorMod(value, modBase) < base;
 		}
 		return false;
 	}


### PR DESCRIPTION
This pull request is intended to resolve Issue #10. 

The issue was that the `%` operator in Java behaves differently for negative numbers than we wanted for our function. The solution was to replace instances of `a % b` with `floorMod(a, b)`